### PR TITLE
Rewrite `check_font_families()` to check for presence of Public Sans

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,6 @@ Imports:
     dplyr,
     flextable,
     ggplot2,
-    glue,
     palettes,
     officer,
     purrr,

--- a/R/load_showtext.R
+++ b/R/load_showtext.R
@@ -1,26 +1,46 @@
-#' Import showtext to make use of DoE fonts
+#' Activate `showtext` and check for presence of Public Sans font family
 #'
+#' [theme_doe()] uses `showtext` to allow R graphics devices to render the
+#' Public Sans font family. Use `check_font_families()` to check that Public
+#' Sans is available and to activate `showtext`.
+#'
+#' @return `check_font_families()` does not have a return value and is called
+#'   for its side effects.
+#'
+#' @seealso [showtext::showtext_auto()] and [Public
+#'   Sans](https://digitalnsw.github.io/public-sans/).
 #' @export
 check_font_families <- function() {
-  if (!suppressWarnings(any(file.exists(sysfonts::font_paths("Public Sans"))))) {
-    glue::glue_col("The font {underline Public Sans} is not installed in any of the search paths.
-  Please download the fonts from {blue https://fonts.google.com/specimen/Public+Sans}
-  And then install the fonts, following the instructions here:
-  {blue https://support.microsoft.com/en-us/windows/how-to-install-or-remove-a-font-in-windows-f12d0657-2fc8-7613-c76f-88d043b334b8#ID0EDH}
-  \n\n
-  ", .literal = TRUE)
-  }
+  if ("Public Sans" %in% sysfonts::font_families()) {
+    # Ensure any newly opened graphics device uses `showtext` to draw text
+    showtext::showtext_auto()
+  } else {
+    # Do the required files and faces exist?
+    fonts <- sysfonts::font_files()
+    public_sans <- fonts[fonts$family == "Public Sans",]
+    faces <- list(regular = "PublicSans-Regular.ttf",
+                  bold = "PublicSans-Bold.ttf",
+                  italic = "PublicSans-Italic.ttf",
+                  bolditalic = "PublicSans-BoldItalic.ttf")
 
-  if ((.Platform$OS.type == "windows") & (!"Public Sans" %in% sysfonts::font_families())) {
-    sysfonts::font_add("Public Sans",
-      regular = "PublicSans-Regular.ttf",
-      bold = "PublicSans-Bold.ttf",
-      italic = "PublicSans-Italic.ttf",
-      bolditalic = "PublicSans-BoldItalic.ttf"
-    )
-    # font.families()
+    if (setequal(intersect(public_sans$file, faces), faces)) {
+      sysfonts::font_add("Public Sans",
+                         regular = faces$regular,
+                         bold = faces$bold,
+                         italic = faces$italic,
+                         bolditalic = faces$bolditalic)
+    } else {
+       cli::cli_warn(
+        message = c(
+          "!" = "The font family {.strong Public Sans} is not installed in any of
+              your operating system's font search paths. {.fn theme_doe}
+              requires `PublicSans-Regular.ttf`, `PublicSans-Bold.ttf`,
+              `PublicSans-Italic.ttf`, and `PublicSans-BoldItalic.ttf`.",
+          "i" = "Please download and install Public Sans from
+              {.url https://digitalnsw.github.io/public-sans/download/}."
+        )
+      )
+    }
+    showtext::showtext.auto()
   }
-
-  # set showtext_auto()  ----------------------------------------------------
-  showtext::showtext_auto() # call once so any newly opened graphics device uses showtext to draw text
 }

--- a/man/check_font_families.Rd
+++ b/man/check_font_families.Rd
@@ -2,10 +2,19 @@
 % Please edit documentation in R/load_showtext.R
 \name{check_font_families}
 \alias{check_font_families}
-\title{Import showtext to make use of DoE fonts}
+\title{Activate \code{showtext} and check for presence of Public Sans font family}
 \usage{
 check_font_families()
 }
+\value{
+\code{check_font_families()} does not have a return value and is called
+for its side effects.
+}
 \description{
-Import showtext to make use of DoE fonts
+\code{\link[=theme_doe]{theme_doe()}} uses \code{showtext} to allow R graphics devices to render the
+Public Sans font family. Use \code{check_font_families()} to check that Public
+Sans is available and to activate \code{showtext}.
+}
+\seealso{
+\code{\link[showtext:showtext_auto]{showtext::showtext_auto()}} and \href{https://digitalnsw.github.io/public-sans/}{Public Sans}.
 }

--- a/man/doestyle-package.Rd
+++ b/man/doestyle-package.Rd
@@ -4,17 +4,25 @@
 \name{doestyle-package}
 \alias{doestyle}
 \alias{doestyle-package}
-\title{doestyle: Apply Department of Education branding to figures and tables}
+\title{doestyle: NSW Department of Education branding for figures and tables}
 \description{
 doestyle is an R package containing functions to help produce brand-compliant figures for NSW Department of Education publications.
+}
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://nsw-education.github.io/doestyle/}
+  \item Report bugs at \url{https://github.com/nsw-education/doestyle/issues}
+}
+
 }
 \author{
 \strong{Maintainer}: Samuel Gardiner \email{samuel.gardiner7@det.nsw.edu.au} (\href{https://orcid.org/0000-0002-6752-6969}{ORCID})
 
 Authors:
 \itemize{
-  \item Matthew Finkbeiner \email{matthew.finkbeiner@det.nsw.edu.au}
-  \item Jonathan McGuire \email{jonathan.mcguire1@det.nsw.edu.au}
+  \item Matthew Finkbeiner (\href{https://orcid.org/0000-0003-0373-8150}{ORCID})
+  \item Jonathan McGuire
 }
 
 }

--- a/vignettes/extending_theme_doe.Rmd
+++ b/vignettes/extending_theme_doe.Rmd
@@ -28,7 +28,7 @@ library(stringr)
 
 ## Examples
 
-`doestyle` includes an example dataset: `public_schools`, the NSW Public Schools Master dataset.
+`doestyle` includes an example dataset: [public_schools], the NSW Public Schools Master dataset.
 
 ```{r data-setup, warning = FALSE}
 head(public_schools)
@@ -41,7 +41,7 @@ public_schools |>
   filter(str_detect(Principal_network, "Connected Communities")) |>
   ggplot(aes(x = Principal_network, fill = Level_of_schooling)) +
   geom_bar(colour = "black", position = position_dodge(preserve = "single")) +
-  theme_doe() +
+  theme_doe(base_family = "sans") +
   labs(y = "Schools", x = "") +
   scale_fill_doe()
 ```
@@ -53,7 +53,8 @@ public_schools |>
   filter(str_detect(Principal_network, "Connected Communities")) |>
   ggplot(aes(x = Principal_network, fill = Level_of_schooling)) +
   geom_bar(colour = "black", position = position_dodge(preserve = "single")) +
-  theme_doe(axis.text.x = element_text(color = 'blue', 
+  theme_doe(base_family = "sans",
+            axis.text.x = element_text(color = 'blue', 
                                        angle = 15, # add angle to x-axis labels
                                        hjust = 0.75,
                                        vjust = 1), 


### PR DESCRIPTION
- Rewrite `check_font_families()` to check for presence of Public Sans TTF files
- Remove operating system-specific code
- Improve documentation for `check_font_families()`
- Don't use Public Sans in prerendered vignettes, for now, as it isn't available in the CI environment (see #4)

Resolves #31